### PR TITLE
Experiment Saving Edits - Integration with pandas 

### DIFF
--- a/docs/examples/experiment_saving_example.ipynb
+++ b/docs/examples/experiment_saving_example.ipynb
@@ -130,7 +130,7 @@
     "    binary_sweep_parameters=binary_sweep_parameters,\n",
     "    weighted_sweep_parameters=weighted_sweep_parameters,\n",
     "    num_simulations=num_simulations,\n",
-    "    distance_matrix=[distance_matrix]\n",
+    "    distance_matrix=[distance_matrix],\n",
     ")"
    ]
   },
@@ -192,7 +192,7 @@
     "\n",
     "1.  Instantiate `ExperimentEvaluation`.\n",
     "2.  Use `.save_experiments()` to save the list of experiment objects. This will typically save to a file for later access.\n",
-    "3.  Use `.query_experiments()` to filter and retrieve specific experiments from the saved set based on their parameters."
+    "3.  Use `.get_dataframe_of_results` to save parameters with eta and gamma for further analysis"
    ]
   },
   {
@@ -202,23 +202,37 @@
    "outputs": [],
    "source": [
     "# The ExperimentEvaluation class handles saving and loading\n",
-    "eval_handler = ExperimentEvaluation()\n",
+    "eval_handler = ExperimentEvaluation('./experiment_results')\n",
     "\n",
     "# Save the list of experiments\n",
-    "eval_handler.save_experiments(experiments)\n",
-    "print(f\"Saved {len(experiments)} experiment(s).\")\n",
+    "eval_handler.save_experiments(experiments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output list of parameters that can be saved to a dataframe\n",
+    "eval_handler.list_experiment_parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a dataframe with the results and save to a CSV file\n",
+    "gnm_results_dataframe = eval_handler.get_dataframe_of_results([\n",
+    "        'eta',\n",
+    "        'gamma',\n",
+    "        'mean_of_max_ks_per_connectome',\n",
+    "        'generative_rule'\n",
+    "])\n",
     "\n",
-    "# Query the experiments by a binary parameter\n",
-    "print(\"\\nQuerying for generative_rule = 'MatchingIndex'...\")\n",
-    "query_by_rule = eval_handler.query_experiments(by='generative_rule', value='MatchingIndex')\n",
-    "print(f\"Found {len(query_by_rule)} experiment(s).\")\n",
-    "print(query_by_rule)\n",
-    "\n",
-    "# Query the experiments by a weighted parameter\n",
-    "print(\"\\nQuerying for alpha = 0.01...\")\n",
-    "query_by_alpha = eval_handler.query_experiments(by='alpha', value=0.01)\n",
-    "print(f\"Found {len(query_by_alpha)} experiment(s).\")\n",
-    "print(query_by_alpha)"
+    "gnm_results_dataframe.to_csv('./gnm_results.csv')"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "wheel==0.44.0",
     "zipp==3.21.0",
     "wandb==0.15.12",
+    "numpy==2.1.2",
 ]
 
 keywords = [

--- a/src/gnm/defaults/get_defaults.py
+++ b/src/gnm/defaults/get_defaults.py
@@ -21,12 +21,15 @@ Functions:
 """
 
 import torch
+import json
 import os
+import pickle
 from jaxtyping import Float, jaxtyped
 from typing import Optional
 from typeguard import typechecked
 
 from gnm.utils import binary_checks, weighted_checks
+from gnm.fitting.experiment_dataclasses import Experiment
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -82,6 +85,10 @@ def display_available_defaults():
     print("=== Weighted networks ===")
     weighted_consensus_networks_path = os.path.join(BASE_PATH, "weighted_networks")
     for file in os.listdir(weighted_consensus_networks_path):
+        print(file.split(".")[0])
+    print("=== Experiment examples ===")
+    experiment_examples_path = os.path.join(BASE_PATH, "experiment_dataclass_examples")
+    for file in os.listdir(experiment_examples_path):
         print(file.split(".")[0])
 
 
@@ -326,3 +333,28 @@ def get_smoothing_matrix(
     smoothing_matrix = smoothing_matrix / smoothing_matrix.sum(axis=1, keepdims=True)
 
     return smoothing_matrix
+
+
+def get_experiment_index_file() -> dict[str]:
+    r"""Load the default experiment index file.
+
+    This function loads the default experiment index file, which contains metadata
+    about pre-defined experiment configurations for generative network models.
+
+    Returns:
+        A dictionary representing the contents of the experiment index file.
+    
+    Examples:
+        >>> from gnm.defaults import get_experiment_index_file
+        >>> index_file = get_experiment_index_file()
+        >>> index_file.keys()
+    """
+
+    PATH = os.path.join(
+        BASE_PATH, "experiment_dataclass_examples", "gnm_index.json"
+    )
+
+    with open(PATH, "r") as f:
+        index_file = json.load(f)
+
+    return index_file

--- a/src/gnm/fitting/experiment_saving.py
+++ b/src/gnm/fitting/experiment_saving.py
@@ -133,7 +133,6 @@ class ExperimentEvaluation():
         if not self.save:
             warn('Parameter Save is False - not saving experiment to disk or index file')
             return
-        
 
         binary_evaluations = experiment_dataclass.evaluation_results.binary_evaluations
         experiment_key = list(binary_evaluations.keys())[0]
@@ -193,10 +192,15 @@ class ExperimentEvaluation():
             return formatted_config
 
         self.index_file['experiment_configs'][experiment_name] = formatted_config
-        
-        # overwrite previous file
+
+        # add to json index file
+        with open(os.path.join(self.path, "gnm_index.json"), "r") as f:
+            data = json.load(f)
+
+        data['experiment_configs'][experiment_name] = formatted_config
+
         with open(os.path.join(self.path, "gnm_index.json"), "w") as f:
-            json.dump(self.index_file, f, indent=4)
+            json.dump(data, f, indent=4)
 
         self._refresh_index_file()
         

--- a/src/gnm/fitting/experiment_saving.py
+++ b/src/gnm/fitting/experiment_saving.py
@@ -1,74 +1,102 @@
+r"""Experiment saving and management for generative network model experiments.
+
+This module provides tools for saving, loading, querying, and managing generative network
+model experiments. It includes an index file system for tracking experiments and their
+parameters, enabling efficient retrieval and analysis of experimental results.
+
+The main components are:
+
+- ExperimentEvaluation class for managing experiment storage and retrieval
+- Methods for querying experiments by parameter values
+- Tools for exporting results to DataFrames for further analysis
+"""
+
 import json
-import pickle
-from datetime import datetime
-from warnings import warn
-import uuid
+import os
 from dataclasses import fields, asdict
+from datetime import datetime
+from typing import List, Dict, Any, Optional, Union
+from warnings import warn
+
+import numpy as np
+import pandas as pd
+import torch
+from jaxtyping import jaxtyped
+from typeguard import typechecked
+
 from .experiment_dataclasses import (
     Experiment,
     BinarySweepParameters,
-    WeightedSweepParameters
+    WeightedSweepParameters,
 )
-import os
-import torch
-from collections import defaultdict
-import pandas as pd
-import numpy as np
 
-"""
-This module provides functionality for managing and saving experiment data for generative network models. 
-It includes the `ExperimentEvaluation` class, which handles saving experiments, managing an index file, 
-querying experiments, and other related operations.
 
-Classes:
-    - ExperimentEvaluation: Handles saving, querying, and managing experiment data and configurations.
+class ExperimentEvaluation:
+    r"""Manager for saving, loading, and querying generative network model experiments.
 
-Usage:
-    The `ExperimentEvaluation` class can be used to:
-    - Save experiments and their configurations.
-    - Query experiments based on specific variables and values.
-    - Manage an index file that tracks experiment configurations.
-    - Delete or clean up experiment data.
+    This class provides a comprehensive interface for persisting experimental results
+    and their associated metadata. It maintains an index file (JSON) that tracks all
+    saved experiments and their parameters, enabling efficient queries and retrieval.
 
-Example:
-    evaluator = ExperimentEvaluation(path="experiment_data", index_file_path="index.json")
-    evaluator.save_experiments([experiment1, experiment2])
-    results = evaluator.query_experiments(value=0.5, by="alpha")
-"""
+    The class supports:
 
-class ExperimentEvaluation():
-    """
-    The `ExperimentEvaluation` class provides functionality for managing and saving experiment data for generative network models. 
-    It handles creating directories, managing index files, saving experiment configurations, and querying experiments.
-    
+    - Saving experiments with automatic parameter extraction
+    - Querying experiments by parameter values
+    - Deleting individual experiments
+    - Exporting results to pandas DataFrames
+
     Attributes:
-        - path (str): Directory where experiment data is stored. Defaults to 'generative_model_experiments'.
-        - index_path (str): Path to the index file that tracks experiment configurations.
-        - variables_to_save (list): List of variables to save, excluding those specified in `variables_to_ignore`.
-    
-    Methods:
-        - __init__(path=None, index_file_path=None, variables_to_ignore=[]): Initializes the class, sets up paths, and prepares the index file.
-        - _refresh_index_file(): Reloads the index file from disk or creates it if it doesn't exist.
-        - _make_index_file(): Creates a new index file with initial data.
-        - save_experiments(experiments): Saves a list of `Experiment` objects to disk.
-        - _save_experiment(experiment_dataclass, experiment_name='gnm_experiment'): Saves a single experiment and updates the index file.
-        - view_experiments(): Placeholder for viewing experiments as a table or saving them as CSV.
-        - _sort_experiments(experiments, variable_to_sort_by, get_names_only=False): Sorts experiments by a specified variable.
-        - clean_index_file(): Placeholder for cleaning up the index file.
-        - _ask_loop(question): Prompts the user for confirmation with a yes/no question.
-        - delete_experiment(experiment_name, ask_first=True): Deletes an experiment and removes it from the index file.
-        - purge_index_file(): Placeholder for purging the index file.
-        - _is_similar_wording(variable_word, verbose=True): Suggests the most similar variable name if a given name is not found.
-        - query_experiments(value=None, by=None, limit=float('inf'), verbose=True): Queries experiments based on a variable and value.
-        - open_experiments_by_name(experiment_names): Opens experiments by their names and returns their data.
-    
-    Usage:
-        evaluator = ExperimentEvaluation(path="experiment_data", index_file_path="index.json")
-        evaluator.save_experiments([experiment1, experiment2])
-        results = evaluator.query_experiments(value=0.5, by="alpha")
+        save:
+            Whether to persist experiments to disk. If False, experiments are processed
+            but not saved.
+        path:
+            Directory path where experiment data and index file are stored.
+        index_path:
+            Full path to the JSON index file.
+        variables_to_save:
+            List of parameter names to track in the index file.
+        index_file:
+            The loaded index file data (dictionary).
+
+    Examples:
+        >>> from gnm.fitting import ExperimentEvaluation
+        >>> # Create an experiment manager
+        >>> manager = ExperimentEvaluation(path='my_experiments')
+        >>> # Save experiments from a sweep
+        >>> manager.save_experiments(experiments)
+        >>> # Query experiments with specific parameters
+        >>> matching = manager.query_experiments(value=0.5, by='eta')
+        >>> # Get results as a DataFrame
+        >>> df = manager.get_dataframe_of_results(
+        ...     parameters=['eta', 'gamma', 'mean_of_max_ks_per_connectome']
+        ... )
+
+    See Also:
+        - [`fitting.Experiment`][gnm.fitting.Experiment]: The dataclass representing an experiment
+        - [`fitting.perform_sweep`][gnm.fitting.perform_sweep]: Function to run parameter sweeps
     """
 
-    def __init__(self, path=None, index_file_path=None, variables_to_ignore=[], save=True):#
+    @jaxtyped(typechecker=typechecked)
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        index_file_path: Optional[str] = None,
+        variables_to_ignore: List[str] = [],
+        save: bool = True,
+    ):
+        r"""
+        Args:
+            path:
+                Directory path where experiments will be saved. Defaults to
+                'generative_model_experiments' if not specified.
+            index_file_path:
+                Name of the JSON index file. Defaults to 'gnm_index.json'.
+            variables_to_ignore:
+                List of parameter names to exclude from tracking.
+            save:
+                Whether to persist experiments to disk. Set to False for
+                in-memory processing only.
+        """
         self.save = save
 
         if path is None:
@@ -93,22 +121,31 @@ class ExperimentEvaluation():
         if self.save:
             self._refresh_index_file()
 
-    def _refresh_index_file(self):
+    def _refresh_index_file(self) -> None:
+        r"""Reload the index file from disk into memory.
+
+        Creates the index file if it does not exist, then loads its contents
+        into the `index_file` attribute.
+        """
         if not os.path.exists(self.index_path):
             self._make_index_file()
 
         with open(self.index_path, "r") as f:
             data = json.load(f)
-        
+
         self.index_file = data
 
-    def _make_index_file(self):
+    def _make_index_file(self) -> None:
+        r"""Create a new index file with initial metadata.
+
+        Initializes a JSON file with the current date and an empty
+        experiment configurations dictionary.
+        """
         date = datetime.now()
         date_formatted = date.strftime("%d/%m/%Y")
         json_initial_data = {
-            'date':date_formatted,
-            'experiment_configs':{
-            }
+            "date": date_formatted,
+            "experiment_configs": {},
         }
 
         with open(self.index_path, "w") as f:
@@ -116,44 +153,89 @@ class ExperimentEvaluation():
 
         self._refresh_index_file()
 
-    """
-    Saves a list of experiments to disk. Each experiment is an instance of the Experiment dataclass.
-    The experiments are saved in a specified directory, and the index file is updated accordingly.
-    """
-    def save_experiments(self, experiments:list[Experiment]):
+    @jaxtyped(typechecker=typechecked)
+    def save_experiments(self, experiments: Union[Experiment, List[Experiment]]) -> None:
+        r"""Save a list of experiments to disk.
+
+        Each experiment is saved and indexed for later retrieval. The experiments
+        are instances of the Experiment dataclass containing run configurations
+        and evaluation results.
+
+        Args:
+            experiments:
+                A single Experiment or list of Experiment instances to save.
+
+        See Also:
+            - [`fitting.Experiment`][gnm.fitting.Experiment]: The experiment dataclass
+            - [`ExperimentEvaluation.query_experiments`][gnm.fitting.ExperimentEvaluation.query_experiments]: Retrieve saved experiments
+        """
         if not isinstance(experiments, list):
             experiments = [experiments]
         for experiment in experiments:
             self._save_experiment(experiment)
 
-    """
-    Extracts information from experiment dataclass and saves in json index file for later parsing
-    """
-    def _save_experiment(self, experiment_dataclass:Experiment, experiment_name='gnm_experiment'):
+    @jaxtyped(typechecker=typechecked)
+    def _save_experiment(
+        self,
+        experiment_dataclass: Experiment,
+        experiment_name: str = "gnm_experiment",
+    ) -> Optional[Dict[str, Any]]:
+        r"""Extract information from experiment dataclass and save to index file.
+
+        Processes an experiment's parameters and evaluation results, formats them
+        for JSON serialization, and appends them to the index file.
+
+        Args:
+            experiment_dataclass:
+                The experiment to save.
+            experiment_name:
+                Base name for the experiment entry. A random suffix is appended
+                to ensure uniqueness.
+
+        Returns:
+            If save is False, returns the formatted configuration dictionary.
+            Otherwise returns None after saving to disk.
+        """
         if not self.save:
-            warn('Parameter Save is False - not saving experiment to disk or index file')
+            warn(
+                "Parameter Save is False - not saving experiment to disk or index file"
+            )
             return
 
         binary_evaluations = experiment_dataclass.evaluation_results.binary_evaluations
         experiment_key = list(binary_evaluations.keys())[0]
         if len(binary_evaluations) > 1:
-            warn('Multiple binary evaluations found - only the first will be saved in the index file.')
-        
+            warn(
+                "Multiple binary evaluations found - only the first will be saved "
+                "in the index file."
+            )
+
         binary_evals = binary_evaluations[experiment_key]
-        per_connectome_binary_evals = {i: np.round(binary_evals[i].cpu().numpy(), 4).tolist() for i in range(binary_evals.shape[0])}
+        per_connectome_binary_evals = {
+            i: np.round(binary_evals[i].cpu().numpy(), 4).tolist()
+            for i in range(binary_evals.shape[0])
+        }
 
         n_participants = binary_evals.shape[0]
 
         # may ignore weighted parameters if set to None
         all_config = asdict(experiment_dataclass.run_config.binary_parameters)
 
-        all_config.update({
-            'n_participants': n_participants,
-            'mean_of_max_ks_per_connectome': binary_evals.mean(axis=1).cpu().numpy().tolist(),
-            'std_of_max_ks_per_connectome': binary_evals.std(axis=1).cpu().numpy().tolist(),
-            'per_connectome_binary_evals': per_connectome_binary_evals
-        })
-        
+        all_config.update(
+            {
+                "n_participants": n_participants,
+                "mean_of_max_ks_per_connectome": binary_evals.mean(axis=1)
+                .cpu()
+                .numpy()
+                .tolist(),
+                "std_of_max_ks_per_connectome": binary_evals.std(axis=1)
+                .cpu()
+                .numpy()
+                .tolist(),
+                "per_connectome_binary_evals": per_connectome_binary_evals,
+            }
+        )
+
         if experiment_dataclass.run_config.weighted_parameters is not None:
             all_config.update(asdict(experiment_dataclass.run_config.weighted_parameters))
 
@@ -161,274 +243,486 @@ class ExperimentEvaluation():
             weighted_experiment_key = list(weighted_evals.keys())[0]
             weighted_evals = weighted_evals[weighted_experiment_key]
             if len(weighted_evals) > 1:
-                warn('Multiple weighted evaluations found - only the first will be saved in the index file.')
-            per_connectome_weighted_evals = {i: weighted_evals[i].cpu().numpy().tolist() for i in range(weighted_evals.shape[0])}
-            all_config.update({
-                'mean_of_weighted_ks_per_connectome': weighted_evals.mean(axis=1).cpu().numpy().tolist(),
-                'std_of_weighted_ks_per_connectome': weighted_evals.std(axis=1).cpu().numpy().tolist(),
-                'per_connectome_weighted_evals': per_connectome_weighted_evals
-            })
-    
-        # de-tensor floating and int values
+                warn(
+                    "Multiple weighted evaluations found - only the first will be "
+                    "saved in the index file."
+                )
+            per_connectome_weighted_evals = {
+                i: weighted_evals[i].cpu().numpy().tolist()
+                for i in range(weighted_evals.shape[0])
+            }
+            all_config.update(
+                {
+                    "mean_of_weighted_ks_per_connectome": weighted_evals.mean(axis=1)
+                    .cpu()
+                    .numpy()
+                    .tolist(),
+                    "std_of_weighted_ks_per_connectome": weighted_evals.std(axis=1)
+                    .cpu()
+                    .numpy()
+                    .tolist(),
+                    "per_connectome_weighted_evals": per_connectome_weighted_evals,
+                }
+            )
+
+        # De-tensor floating and int values for JSON serialization
         formatted_config = {}
         for key, value in all_config.items():
             if isinstance(value, torch.Tensor):
                 formatted_config[key] = value.item()
             elif isinstance(value, dict):
                 formatted_config[key] = value
-            elif not isinstance(value, (str, int, float, list)) and hasattr(value, "__class__"):
+            elif (
+                not isinstance(value, (str, int, float, list))
+                and hasattr(value, "__class__")
+            ):
                 try:
                     class_name = value.__class__.__name__
                     formatted_config[key] = class_name
-                except:
-                    warn(f'Attribute {value} could not be saved - no name or class instance found.')
+                except Exception:
+                    warn(
+                        f"Attribute {value} could not be saved - no name or class "
+                        "instance found."
+                    )
             elif isinstance(value, list):
                 formatted_config[key] = value
             elif isinstance(value, (int, float, str)):
                 formatted_config[key] = value
 
-        # return names and values of parameters if save is False - mainly used for wandb
+        # Return names and values of parameters if save is False - mainly used for wandb
         if not self.save:
             return formatted_config
 
-        # add to json index file
+        # Add to JSON index file
         with open(os.path.join(self.path, "gnm_index.json"), "r") as f:
             data = json.load(f)
 
-        def random_string(length=6):
-            letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-            return ''.join(np.random.choice(list(letters), size=length))
+        def random_string(length: int = 6) -> str:
+            r"""Generate a random alphanumeric string."""
+            letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+            return "".join(np.random.choice(list(letters), size=length))
 
-        data['experiment_configs'][experiment_name + '_' + random_string()] = (formatted_config)
+        data["experiment_configs"][experiment_name + "_" + random_string()] = (
+            formatted_config
+        )
 
         with open(os.path.join(self.path, "gnm_index.json"), "w") as f:
             json.dump(data, f, indent=4)
 
         self._refresh_index_file()
-        
 
-    # view the experiments as a table and save as csv if you want
-    def view_experiments():
+    def view_experiments(self) -> None:
+        r"""View experiments as a table and optionally save as CSV.
+
+        Note:
+            This method is not yet implemented.
+        """
         pass
 
-    def _sort_experiments(self, experiments, variable_to_sort_by, get_names_only=False):
+    def _sort_experiments(
+        self,
+        experiments: Dict[str, Dict[str, Any]],
+        variable_to_sort_by: str,
+        get_names_only: bool = False,
+    ) -> Union[Dict[str, Any], List[str]]:
+        r"""Sort experiments by a specified variable.
 
-        def combine_dictionary_by_key(list_of_dictionaries, key_value_items):
+        Groups experiments by the type of their sorting variable (numbers, strings,
+        lists) and sorts each group appropriately.
+
+        Args:
+            experiments:
+                Dictionary mapping experiment names to their configuration data.
+            variable_to_sort_by:
+                The parameter name to sort by.
+            get_names_only:
+                If True, return only the sorted experiment names.
+                If False, return a dictionary with names and their sort values.
+
+        Returns:
+            Either a list of experiment names (if get_names_only=True) or a
+            dictionary mapping names to their sort values.
+        """
+
+        def combine_dictionary_by_key(
+            list_of_dictionaries: List[Dict[str, Any]],
+            key_value_items: Dict[str, Dict[str, Any]],
+        ) -> Dict[str, Any]:
+            r"""Combine dictionaries by extracting values for a specific key."""
             exp = {}
             for dictionary in list_of_dictionaries:
                 for name in list(dictionary.keys()):
                     exp[name] = key_value_items[name][variable_to_sort_by]
-
             return exp
 
         experiment_names = list(experiments.keys())
 
-        # keys = experiment name, values = experiment values of the given variable to sort by
-        sorting_dict = {experiment_name:value for experiment_name, value in zip(experiment_names, [experiments[name][variable_to_sort_by] for name in experiment_names])}
-        
-        # # convert strings back to original 
-        # sorting_dict = {experiment_name:eval(value) for experiment_name, value in sorting_dict.items()}
+        # Keys = experiment name, values = experiment values of the given variable
+        sorting_dict = {
+            experiment_name: value
+            for experiment_name, value in zip(
+                experiment_names,
+                [experiments[name][variable_to_sort_by] for name in experiment_names],
+            )
+        }
 
-        # iterate to check types
+        # Iterate to check types and separate by type
         sorting_dict_numbers = {}
         sorting_dict_strings = {}
-        sroting_dict_lists = {}
+        sorting_dict_lists = {}
         for key, value in sorting_dict.items():
-            if isinstance(value, int) or isinstance(value, float):
+            if isinstance(value, (int, float)):
                 sorting_dict_numbers[key] = value
             elif isinstance(value, str):
                 sorting_dict_strings[key] = value
             else:
-                sroting_dict_lists[key] = value
+                sorting_dict_lists[key] = value
 
-        
-        # sort num, string dictionaries by values (sorted requires same datatype) - no point in sorting lists
-        sorting_dict_numbers = dict(sorted(sorting_dict_numbers.items(), key=lambda item: item[1]))
-        sorting_dict_strings = dict(sorted(sorting_dict_strings.items(), key=lambda item: item[1]))
+        # Sort num, string dictionaries by values (sorted requires same datatype)
+        sorting_dict_numbers = dict(
+            sorted(sorting_dict_numbers.items(), key=lambda item: item[1])
+        )
+        sorting_dict_strings = dict(
+            sorted(sorting_dict_strings.items(), key=lambda item: item[1])
+        )
 
-        # create a new dictonary and add experiments based on the order of sorted_experiments
-        # but with all the data included in experiments, rather than just the value used for sorting
-        sorted_experiments = combine_dictionary_by_key([sorting_dict_numbers, sorting_dict_strings, sroting_dict_lists], experiments)
-        
+        # Create a new dictionary with experiments in sorted order
+        sorted_experiments = combine_dictionary_by_key(
+            [sorting_dict_numbers, sorting_dict_strings, sorting_dict_lists],
+            experiments,
+        )
+
         if get_names_only:
             sorted_experiments = list(sorted_experiments.keys())
-        
+
         return sorted_experiments
-    
-    def clean_index_file(self):
+
+    def clean_index_file(self) -> None:
+        r"""Clean the index file by removing invalid or orphaned entries.
+
+        Note:
+            This method is not yet implemented.
+        """
         pass
 
-    def _ask_loop(self, question):
+    def _ask_loop(self, question: str) -> bool:
+        r"""Prompt the user for confirmation in a loop.
+
+        Args:
+            question:
+                The question to display to the user.
+
+        Returns:
+            True if user confirms (y), False if user declines (n).
+        """
         answer = None
-        question = question + '\ny=confirm, n=exit\n> '
+        question = question + "\ny=confirm, n=exit\n> "
         while answer is None:
             user_input = input(question).lower()
-            if user_input == 'y':
+            if user_input == "y":
                 answer = True
-            elif user_input == 'n':
+            elif user_input == "n":
                 answer = False
             else:
-                print('Invalid response. Must be y for yes or n for no.')
+                print("Invalid response. Must be y for yes or n for no.")
 
         return answer
 
-    """
-    Deletes an experiment from the index file and removes the corresponding file from disk.
-    """
-    def delete_experiment(self, experiment_name, ask_first=True):
+    @jaxtyped(typechecker=typechecked)
+    def delete_experiment(
+        self, experiment_name: str, ask_first: bool = True
+    ) -> None:
+        r"""Delete an experiment from the index file.
+
+        Removes the specified experiment from the index file. Optionally
+        prompts for confirmation before deletion.
+
+        Args:
+            experiment_name:
+                The name of the experiment to delete.
+            ask_first:
+                If True, prompt for confirmation before deletion.
+                Defaults to True.
+        """
         if not self.save:
-            warn('Parameter Save is False - no index file present so returning null')
+            warn("Parameter Save is False - no index file present so returning null")
             return
 
-        if not experiment_name in self.index_file['experiment_configs']:
-            warn(f'Experiment {experiment_name} not found in index file, exiting.')
+        if experiment_name not in self.index_file["experiment_configs"]:
+            warn(f"Experiment {experiment_name} not found in index file, exiting.")
+            return
 
         if ask_first:
-            response = self._ask_loop(f'Are you sure you want to delete experiment {experiment_name}?')
-            if response == False:
-                print('Aborting....')
+            response = self._ask_loop(
+                f"Are you sure you want to delete experiment {experiment_name}?"
+            )
+            if response is False:
+                print("Aborting....")
                 return
 
-        del self.index_file['experiment_configs'][experiment_name]
+        del self.index_file["experiment_configs"][experiment_name]
 
-        print(f'Experiment {experiment_name} deleted from index file.')
+        print(f"Experiment {experiment_name} deleted from index file.")
 
-    def purge_index_file(self):
+    def purge_index_file(self) -> None:
+        r"""Remove all experiments from the index file.
+
+        Note:
+            This method is not yet implemented.
+        """
         pass
 
-    def _is_similar_wording(self, variable_word, verbose=True):
+    def _is_similar_wording(self, variable_word: str, verbose: bool = True) -> str:
+        r"""Find the most similar variable name to a given word.
+
+        Uses character frequency matching to suggest corrections for
+        misspelled parameter names.
+
+        Args:
+            variable_word:
+                The word to find a match for.
+            verbose:
+                If True, print the suggested match.
+
+        Returns:
+            The most similar variable name from the available parameters.
+        """
         all_vars = self.variables_to_save
 
         char_frequency = {}
         for var in all_vars:
-            letters_in_common = [character for character in variable_word if character in var]
+            letters_in_common = [
+                character for character in variable_word if character in var
+            ]
             char_frequency[var] = len(letters_in_common) / len(var)
 
-        char_frequency = dict(sorted(char_frequency.items(), key=lambda item: item[1]))
+        char_frequency = dict(
+            sorted(char_frequency.items(), key=lambda item: item[1])
+        )
         most_likely_word = list(char_frequency.keys())[-1]
 
         if verbose:
-            print(f'Did you mean {most_likely_word}?')
-        
+            print(f"Did you mean {most_likely_word}?")
+
         return most_likely_word
 
-
-    """
-    Queries the index file for experiments matching a specified variable and value.
-    Returns a list of experiment data files that match the criteria.
-    """
+    @jaxtyped(typechecker=typechecked)
     def query_experiments(
-            self, 
-            value=None, 
-            by=None, 
-            limit=float('inf'), 
-            verbose=True
-            ) -> list[Experiment]:
-        if not self.save:
-            warn('Parameter Save is False - no index file present so returning null')
-            return
+        self,
+        value: Optional[Any] = None,
+        by: Optional[str] = None,
+        limit: float = float("inf"),
+        verbose: bool = True,
+    ) -> Optional[List[Experiment]]:
+        r"""Query the index file for experiments matching specified criteria.
 
-        # get all searchable variables
-        all_experiments = self.index_file['experiment_configs']
+        Searches through saved experiments to find those matching a specified
+        parameter value. If no value is provided, returns all experiments
+        sorted by the specified parameter.
+
+        Args:
+            value:
+                The value to match for the specified parameter. If None,
+                returns all experiments sorted by the `by` parameter.
+            by:
+                The parameter name to search or sort by.
+            limit:
+                Maximum number of experiments to return. Defaults to infinity.
+            verbose:
+                If True, print the number of matching experiments found.
+
+        Returns:
+            A list of Experiment data dictionaries matching the criteria,
+            or None if save is False.
+
+        Examples:
+            >>> manager = ExperimentEvaluation(path='my_experiments')
+            >>> # Find all experiments with eta = -2.0
+            >>> experiments = manager.query_experiments(value=-2.0, by='eta')
+            >>> # Get all experiments sorted by gamma
+            >>> sorted_exps = manager.query_experiments(by='gamma')
+
+        See Also:
+            - [`ExperimentEvaluation.find_experiment_by_name`][gnm.fitting.ExperimentEvaluation.find_experiment_by_name]: Find experiments by name
+        """
+        if not self.save:
+            warn("Parameter Save is False - no index file present so returning null")
+            return None
+
+        # Get all searchable variables
+        all_experiments = self.index_file["experiment_configs"]
         if len(all_experiments) == 0:
-            warn(f'No experiments saved in index file {self.index_file}')
+            warn(f"No experiments saved in index file {self.index_file}")
 
         first_experiment = list(all_experiments.keys())[-1]
         first_experiment_data = all_experiments[first_experiment]
         searchable_variables = list(first_experiment_data.keys())
 
-        # make sure variable provided can be searched
+        # Make sure variable provided can be searched
         if by not in searchable_variables:
-            print(f'Variable {by} not in searchable variables. Must be one of {searchable_variables}')
+            print(
+                f"Variable {by} not in searchable variables. "
+                f"Must be one of {searchable_variables}"
+            )
             self._is_similar_wording(by)
-            return
+            return None
 
-        # sort by that variable and return list if no value to search for is specified
+        # Sort by that variable and return list if no value to search for
         if value is None or len(all_experiments) == 1:
-            experiments_sorted = self._sort_experiments(experiments=all_experiments, variable_to_sort_by=by, get_names_only=True)
+            experiments_sorted = self._sort_experiments(
+                experiments=all_experiments,
+                variable_to_sort_by=by,
+                get_names_only=True,
+            )
             return_files = self.open_experiments_by_name(experiments_sorted)
-            return return_files 
-        
-        # iterate through index looking for experiments matching criteria
+            return return_files
+
+        # Iterate through index looking for experiments matching criteria
         to_return = []
-        experiments_sorted = self._sort_experiments(experiments=all_experiments, variable_to_sort_by=by, get_names_only=False)
+        experiments_sorted = self._sort_experiments(
+            experiments=all_experiments,
+            variable_to_sort_by=by,
+            get_names_only=False,
+        )
 
         for experiment_name, experiment_value in experiments_sorted.items():
             if experiment_value == value:
                 to_return.append(experiment_name)
-        
+
         experiment_data_to_return = self.open_experiments_by_name(to_return)
 
         if verbose:
-            print(f'\nFound {len(experiment_data_to_return)} item(s) matching: {by} = {value}')
-        
+            print(
+                f"\nFound {len(experiment_data_to_return)} item(s) matching: "
+                f"{by} = {value}"
+            )
+
         return experiment_data_to_return
-        
-    """
-    Opens experiments by their names and returns their data.
-    If the name is 'test_config', it is skipped.
-    """
-    def find_experiment_by_name(self, experiment_names:list[str]):
-            
+
+    @jaxtyped(typechecker=typechecked)
+    def find_experiment_by_name(
+        self, experiment_names: Union[str, List[str]]
+    ) -> List[Dict[str, Any]]:
+        r"""Retrieve experiment data by experiment names.
+
+        Looks up experiments in the index file by their names and returns
+        their configuration data.
+
+        Args:
+            experiment_names:
+                A single experiment name or list of names to look up.
+
+        Returns:
+            A list of experiment configuration dictionaries for the found
+            experiments. Experiments named 'test_config' are skipped.
+
+        See Also:
+            - [`ExperimentEvaluation.query_experiments`][gnm.fitting.ExperimentEvaluation.query_experiments]: Query experiments by parameter values
+        """
         if isinstance(experiment_names, str):
             experiment_names = [experiment_names]
 
-        tmp_index = self.index_file['experiment_configs']
+        tmp_index = self.index_file["experiment_configs"]
 
         experiments_opened = []
         for name in experiment_names:
-            if name == 'test_config': continue
+            if name == "test_config":
+                continue
 
             if name in tmp_index:
                 experiments_opened.append(tmp_index[name])
             else:
-                warn(f'Experiment {name} not found in index file.')
+                warn(f"Experiment {name} not found in index file.")
 
         return experiments_opened
-    
-    def list_experiment_parameters(self):
-        config = self.index_file['experiment_configs']
+
+    def list_experiment_parameters(self) -> List[str]:
+        r"""List all parameter names tracked in the index file.
+
+        Prints and returns the list of parameter names from the first
+        experiment configuration in the index file.
+
+        Returns:
+            A list of parameter names.
+        """
+        config = self.index_file["experiment_configs"]
         self.variables_to_save = list(config.values())[0].keys()
         print("Experiment Parameters:")
         for var in self.variables_to_save:
-            print(f'   - {var}')
+            print(f"   - {var}")
         return self.variables_to_save
-    
+
+    @jaxtyped(typechecker=typechecked)
     def get_dataframe_of_results(
         self,
-        parameters: list[str] = ['eta', 'gamma', 'mean_of_max_ks_per_connectome'],
-        save_dataframe: bool = True
-        ) -> pd.DataFrame:
-        
+        parameters: List[str] = ["eta", "gamma", "mean_of_max_ks_per_connectome"],
+        save_dataframe: bool = True,
+    ) -> pd.DataFrame:
+        r"""Export experiment results to a pandas DataFrame.
+
+        Compiles results from all experiments in the index file into a
+        DataFrame with one row per connectome per experiment.
+
+        Args:
+            parameters:
+                List of parameter names to include in the DataFrame.
+                Defaults to ['eta', 'gamma', 'mean_of_max_ks_per_connectome'].
+            save_dataframe:
+                If True, save the DataFrame to a CSV file in the experiment
+                directory.
+
+        Returns:
+            A DataFrame containing the specified parameters for all
+            experiments and connectomes.
+
+        Warning:
+            Assumes the default Max KS Distance metric was used during
+            evaluation.
+
+        Examples:
+            >>> manager = ExperimentEvaluation(path='my_experiments')
+            >>> df = manager.get_dataframe_of_results(
+            ...     parameters=['eta', 'gamma', 'mean_of_max_ks_per_connectome']
+            ... )
+            >>> print(df.head())
+
+        See Also:
+            - [`ExperimentEvaluation.query_experiments`][gnm.fitting.ExperimentEvaluation.query_experiments]: Query specific experiments
+        """
         warn("Assumes default Max KS Distance metric was used during evaluation.")
 
-        # reload index file to get latest experiments
+        # Reload index file to get latest experiments
         self._refresh_index_file()
-        
-        all_experiments: dict = self.index_file['experiment_configs']
+
+        all_experiments: Dict[str, Dict[str, Any]] = self.index_file[
+            "experiment_configs"
+        ]
         last_experiment_name = list(all_experiments.keys())[-1]
         last_experiment_data = all_experiments[last_experiment_name]
 
         for param in parameters:
-            if not param in last_experiment_data.keys():
-                warn(f'Parameter {param} not found in experiment binary parameters, skipping...')
+            if param not in last_experiment_data.keys():
+                warn(
+                    f"Parameter {param} not found in experiment binary "
+                    "parameters, skipping..."
+                )
                 parameters.remove(param)
                 continue
 
-        # get n participants
-        n_participants = last_experiment_data['n_participants']
+        # Get n participants
+        n_participants = last_experiment_data["n_participants"]
 
-        # set up empty df
-        results_summary_df = {'connectome_index': []}
+        # Set up empty df
+        results_summary_df: Dict[str, List[Any]] = {"connectome_index": []}
         for param in parameters:
             results_summary_df[param] = []
 
-        base_dict = {param: [] for param in parameters}
-        base_dict['connectome_index'] = []
+        base_dict: Dict[str, List[Any]] = {param: [] for param in parameters}
+        base_dict["connectome_index"] = []
 
         participant_indices = list(range(n_participants))
-        
-        # iterate through experiment json data
+
+        # Iterate through experiment JSON data
         for experiment_name in all_experiments.keys():
             experiment = all_experiments[experiment_name]
 
@@ -439,40 +733,43 @@ class ExperimentEvaluation():
                     param_values = [param_values] * n_participants
 
                 if len(param_values) != n_participants:
-                    warn(f'Parameter {param} in experiment {experiment_name} has length {len(param_values)} but expected {n_participants}, skipping...')
+                    warn(
+                        f"Parameter {param} in experiment {experiment_name} has "
+                        f"length {len(param_values)} but expected {n_participants}, "
+                        "skipping..."
+                    )
                     continue
 
                 base_dict[param].extend(param_values)
-            base_dict['connectome_index'].extend(participant_indices)
-            
-            # append to main dict
+            base_dict["connectome_index"].extend(participant_indices)
+
+            # Append to main dict
             for key in base_dict.keys():
                 results_summary_df[key].extend(base_dict[key])
 
         for key in results_summary_df.keys():
-            print(f'Total entries for {key}: {len(results_summary_df[key])}')
+            print(f"Total entries for {key}: {len(results_summary_df[key])}")
 
         results_summary_df = pd.DataFrame(results_summary_df)
 
-        if len(results_summary_df['connectome_index']) == 0:
+        if len(results_summary_df["connectome_index"]) == 0:
             warn("No results found to compile into DataFrame.")
             return pd.DataFrame()
-        
-        n_unique_connectomes = len(set(results_summary_df['connectome_index']))
-        first_connectome_index = results_summary_df['connectome_index'][0]
-        
+
+        n_unique_connectomes = len(set(results_summary_df["connectome_index"]))
+
         print(f"Compiled results for {n_unique_connectomes} unique connectomes.")
 
         if save_dataframe:
-            csv_path = os.path.join(self.path, 'experiment_results_summary.csv')
+            csv_path = os.path.join(self.path, "experiment_results_summary.csv")
             if os.path.exists(csv_path):
-                if self._ask_loop(f'File {csv_path} already exists. Overwrite?'):
+                if self._ask_loop(f"File {csv_path} already exists. Overwrite?"):
                     results_summary_df.to_csv(csv_path, index=False)
-                    print(f'Saved results summary dataframe to {csv_path}')
+                    print(f"Saved results summary dataframe to {csv_path}")
                 else:
-                    new_name = input('In that case, enter new file name: ')
-                    new_csv_path = os.path.join(self.path, new_name + '.csv')
+                    new_name = input("In that case, enter new file name: ")
+                    new_csv_path = os.path.join(self.path, new_name + ".csv")
                     results_summary_df.to_csv(new_csv_path, index=False)
-                    print(f'Saved results summary dataframe to {new_csv_path}')
+                    print(f"Saved results summary dataframe to {new_csv_path}")
 
         return results_summary_df

--- a/src/gnm/fitting/experiment_saving.py
+++ b/src/gnm/fitting/experiment_saving.py
@@ -191,13 +191,15 @@ class ExperimentEvaluation():
         if not self.save:
             return formatted_config
 
-        self.index_file['experiment_configs'][experiment_name] = formatted_config
-
         # add to json index file
         with open(os.path.join(self.path, "gnm_index.json"), "r") as f:
             data = json.load(f)
 
-        data['experiment_configs'][experiment_name] = formatted_config
+        def random_string(length=6):
+            letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+            return ''.join(np.random.choice(list(letters), size=length))
+
+        data['experiment_configs'][experiment_name + '_' + random_string()] = (formatted_config)
 
         with open(os.path.join(self.path, "gnm_index.json"), "w") as f:
             json.dump(data, f, indent=4)

--- a/src/gnm/fitting/experiment_saving.py
+++ b/src/gnm/fitting/experiment_saving.py
@@ -108,9 +108,6 @@ class ExperimentEvaluation():
         json_initial_data = {
             'date':date_formatted,
             'experiment_configs':{
-                'test_config':{
-                    i:'TEST' for i in self.variables_to_save
-                }
             }
         }
 

--- a/tests/test_experiment_saving.py
+++ b/tests/test_experiment_saving.py
@@ -3,56 +3,131 @@ from gnm.fitting.experiment_dataclasses import Experiment
 from gnm import defaults, fitting, generative_rules, weight_criteria, evaluation
 import torch
 
-DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+def _generate_basic_sweep():
+    DEVICE = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
-distance_matrix = defaults.get_distance_matrix(device=DEVICE)
-binary_consensus_network = defaults.get_binary_network(device=DEVICE)
+    distance_matrix = defaults.get_distance_matrix(device=DEVICE)
+    binary_consensus_network = defaults.get_binary_network(device=DEVICE)
 
-eta_values = torch.Tensor([1]) #torch.linspace(-5, -1, 1)
-gamma_values = torch.Tensor([-1])#torch.linspace(-0.5, 0.5, 1)
-num_connections = int( binary_consensus_network.sum().item() / 2 )
+    eta_values = torch.Tensor([1]) #torch.linspace(-5, -1, 1)
+    gamma_values = torch.Tensor([-1])#torch.linspace(-0.5, 0.5, 1)
+    num_connections = int( binary_consensus_network.sum().item() / 2 )
 
-binary_sweep_parameters = fitting.BinarySweepParameters(
-    eta = eta_values,
-    gamma = gamma_values,
-    lambdah = torch.Tensor([0.0]),
-    distance_relationship_type = ["powerlaw"],
-    preferential_relationship_type = ["powerlaw"],
-    heterochronicity_relationship_type = ["powerlaw"],
-    generative_rule = [generative_rules.MatchingIndex()],
-    num_iterations = [num_connections],
-)
+    binary_sweep_parameters = fitting.BinarySweepParameters(
+        eta = eta_values,
+        gamma = gamma_values,
+        lambdah = torch.Tensor([0.0]),
+        distance_relationship_type = ["powerlaw"],
+        preferential_relationship_type = ["powerlaw"],
+        heterochronicity_relationship_type = ["powerlaw"],
+        generative_rule = [generative_rules.MatchingIndex()],
+        num_iterations = [num_connections],
+    )
 
-weighted_sweep_parameters = fitting.WeightedSweepParameters(
-    alpha = [0.01],
-    optimisation_criterion = [weight_criteria.DistanceWeightedCommunicability(distance_matrix=distance_matrix) ],
-)   
+    weighted_sweep_parameters = fitting.WeightedSweepParameters(
+        alpha = [0.01],
+        optimisation_criterion = [weight_criteria.DistanceWeightedCommunicability(distance_matrix=distance_matrix) ],
+    )   
 
-num_simulations = 1
+    num_simulations = 1
 
-sweep_config = fitting.SweepConfig(
-    binary_sweep_parameters = binary_sweep_parameters,
-    weighted_sweep_parameters = weighted_sweep_parameters,
-    num_simulations = num_simulations,
-    distance_matrix = [distance_matrix]    
-)
+    sweep_config = fitting.SweepConfig(
+        binary_sweep_parameters = binary_sweep_parameters,
+        weighted_sweep_parameters = weighted_sweep_parameters,
+        num_simulations = num_simulations,
+        distance_matrix = [distance_matrix]    
+    )
 
-criteria = [ evaluation.ClusteringKS(), evaluation.DegreeKS(), evaluation.EdgeLengthKS(distance_matrix) ]
-energy = evaluation.MaxCriteria( criteria )
-binary_evaluations = [energy]
-weighted_evaluations = [ evaluation.WeightedNodeStrengthKS(normalise=True), evaluation.WeightedClusteringKS() ]
+    criteria = [ evaluation.ClusteringKS(), evaluation.DegreeKS(), evaluation.EdgeLengthKS(distance_matrix) ]
+    energy = evaluation.MaxCriteria( criteria )
+    binary_evaluations = [energy]
+    weighted_evaluations = [ evaluation.WeightedNodeStrengthKS(normalise=True), evaluation.WeightedClusteringKS() ]
 
-experiments = fitting.perform_sweep(sweep_config=sweep_config, 
-                                binary_evaluations=binary_evaluations, 
-                                real_binary_matrices=binary_consensus_network,
-                                weighted_evaluations=weighted_evaluations,
-                                save_model = False,
-                                save_run_history = False,
-                                verbose=True
-)
+    experiments = fitting.perform_sweep(sweep_config=sweep_config, 
+                                    binary_evaluations=binary_evaluations, 
+                                    real_binary_matrices=binary_consensus_network,
+                                    weighted_evaluations=weighted_evaluations,
+                                    save_model = False,
+                                    save_run_history = False,
+                                    verbose=True
+    )
 
-eval = ExperimentEvaluation()
-print(experiments)
-eval.save_experiments(experiments)
-x = eval.query_experiments(by = 'generative_rule', value='MatchingIndex')
-y = eval.query_experiments(by = 'alpha', value=0.01)
+    assert len(experiments) > 0, 'Experiments not returned or sweep was run incorrectly during unit tests for experiment saving'
+    return experiments
+
+def test_experiment_evaluation_init():
+    """Test ExperimentEvaluation initializes correctly."""
+    eval_handler = ExperimentEvaluation(save=False)
+    
+    assert eval_handler is not None, "ExperimentEvaluation should initialize"
+    assert eval_handler.save is False, "Save attribute should be set correctly"
+    assert eval_handler.path == "generative_model_experiments", "Default path should be set"
+
+
+def test_experiment_evaluation_init_custom_path():
+    """Test ExperimentEvaluation initializes with custom path."""
+    eval_handler = ExperimentEvaluation(path="custom_path", save=False)
+    
+    assert eval_handler.path == "custom_path", "Custom path should be set"
+
+
+def test_save_experiments():
+    """Test saving experiments to disk."""
+    experiments = _generate_basic_sweep()
+    eval_handler = ExperimentEvaluation(path="test_experiments", save=True)
+    
+    # Should not raise an error
+    eval_handler.save_experiments(experiments)
+    
+    # Verify index file was updated
+    assert len(eval_handler.index_file["experiment_configs"]) > 0, "Experiments should be saved to index"
+
+
+def test_save_single_experiment():
+    """Test saving a single experiment (not in a list)."""
+    experiments = _generate_basic_sweep()
+    eval_handler = ExperimentEvaluation(path="test_experiments", save=True)
+    
+    # Should handle single experiment without list wrapper
+    eval_handler.save_experiments(experiments[0])
+    
+    assert len(eval_handler.index_file["experiment_configs"]) > 0, "Single experiment should be saved"
+
+
+def test_list_experiment_parameters():
+    """Test listing experiment parameters."""
+    experiments = _generate_basic_sweep()
+    eval_handler = ExperimentEvaluation(path="test_experiments", save=True)
+    eval_handler.save_experiments(experiments)
+    
+    parameters = eval_handler.list_experiment_parameters()
+    
+    assert parameters is not None, "Parameters should be returned"
+    assert "eta" in parameters, "eta should be in parameters"
+    assert "gamma" in parameters, "gamma should be in parameters"
+
+
+def test_get_dataframe_of_results():
+    """Test getting results as a DataFrame."""
+    experiments = _generate_basic_sweep()
+    eval_handler = ExperimentEvaluation(path="test_experiments", save=True)
+    eval_handler.save_experiments(experiments)
+    
+    df = eval_handler.get_dataframe_of_results(
+        parameters=["eta", "gamma", "mean_of_max_ks_per_connectome"],
+        save_dataframe=False,
+    )
+    
+    assert df is not None, "DataFrame should be returned"
+    assert "eta" in df.columns, "eta should be in DataFrame columns"
+    assert "gamma" in df.columns, "gamma should be in DataFrame columns"
+    assert len(df) > 0, "DataFrame should have rows"
+
+
+def test_experiment_evaluation_no_save_mode():
+    """Test ExperimentEvaluation in no-save mode returns None for queries."""
+    eval_handler = ExperimentEvaluation(save=False)
+    
+    result = eval_handler.query_experiments(value=0.5, by="eta")
+    
+    assert result is None, "Should return None when save=False"


### PR DESCRIPTION
Experiment saving has been edited to provide a more user-friendly experience. 
1. Experiment saving and querying has been removed in place of a get_results_dataframe function that returns a pandas dataframe containing all the experiment parameters, e.g. eta, gamma, ks distance etc. 
2. KS distance is provided via an average over all simulations per connectome. A standard deviation of KS distance is equally provided. Individual simulations can also be accessed via the same method by specifying this parameter. 
3. Doc strings and unit tests are added
4. Minor 'non experiment saving' change - numpy version 2.1.2 is specified after user reported issues with package installation. 